### PR TITLE
Fix code example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,8 +52,8 @@ InvalidKeyError will be raised if a key was not understood
 .. code-block:: python
 
     from system_hotkey import SystemHotkey
-    hk = SystemHotkeys()
-    hk.register(('control', 'shift', 'h'), callback=lambda:print("Easy!"))
+    hk = SystemHotkey()
+    hk.register(('control', 'shift', 'h'), callback=lambda x: print("Easy!"))
 
 A SystemRegisterError will be raised if a hotkey is already in use.
 


### PR DESCRIPTION
This fixes two errors in the readme code example:

1) Fix typo
2) The lambda needs to accept a `ctypes.wintypes.MSG` argument even if it doesn't use it.