### PR TITLE
Python 3.10.4 collections fix + added grave (`) key code

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,8 @@ If for some reason you have to use the python xlib bindings (gpl license), a few
 Usage
 ------
 
+Download this and use `pip install . --user` in root folder to install
+
 **Input Keysyms**
 
 System hotkeys uses the keysym names from xlib for everything besides modifiers.(although case insensitive)

--- a/README.rst
+++ b/README.rst
@@ -9,13 +9,11 @@ Currently no mac or  python2 support :(
 Installation
 ------------
 
-the old
-
 .. code-block:: bash
 
-  pip3 install system_hotkey
+  pip install . --user
 
-should do the trick
+in the root folder
 
 Windows
 ^^^^^^^
@@ -30,8 +28,6 @@ If for some reason you have to use the python xlib bindings (gpl license), a few
 
 Usage
 ------
-
-Download this and use `pip install . --user` in root folder to install
 
 **Input Keysyms**
 

--- a/system_hotkey/system_hotkey.py
+++ b/system_hotkey/system_hotkey.py
@@ -61,6 +61,8 @@ if os.name == 'nt':
         '7':0x37,
         '8':0x38,
         '9':0x39,
+        "grave": 0xC0,
+        "`": 0xC0,
         "up": win32con.VK_UP
         , "kp_up": win32con.VK_UP
         , "down": win32con.VK_DOWN

--- a/system_hotkey/system_hotkey.py
+++ b/system_hotkey/system_hotkey.py
@@ -2,7 +2,7 @@ import os
 import _thread as thread
 import queue
 import time
-import collections
+import collections.abc
 from pprint import pprint
 import struct
 
@@ -125,7 +125,6 @@ if os.name == 'nt':
         , "f23": win32con.VK_F23
         , "f24": win32con.VK_F24
         , "media_play_pause": win32con.VK_MEDIA_PLAY_PAUSE
-        , "media_stop": win32con.VK_MEDIA_STOP
         , "media_next": win32con.VK_MEDIA_NEXT_TRACK
         , "media_previous": win32con.VK_MEDIA_PREV_TRACK
         }
@@ -285,7 +284,7 @@ class MixIn():
 
         thread safe
         '''
-        assert isinstance(hotkey, collections.Iterable) and type(hotkey) not in (str, bytes)
+        assert isinstance(hotkey, collections.abc.Iterable) and type(hotkey) not in (str, bytes)
         if self.consumer == 'callback' and not callback:
             raise TypeError('Function register requires callback argument in non sonsumer mode')
 


### PR DESCRIPTION
I tried the other pull requests and their fixes for python 3.10 didn't work for me.
Disclaimer, I had to remove win32con.VK_MEDIA_STOP. It wouldn't work otherwise.

I also had a need to use the grave key in a key-bind so I added that functionality as well.
Don't know how well this works for other machines because I didn't use win32con, as they don't have that bound either.